### PR TITLE
fix: 修复 TypeScript 类型定义配置错误

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],
-    "types": ["node"],
     "jsx": "react",
     "outDir": "./dist",
     "rootDir": "./src",

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist/main"
+    "outDir": "./dist/main",
+    "types": ["node"]
   },
   "include": ["src/main/**/*", "src/shared/**/*"],
   "exclude": ["node_modules", "dist", "release", "**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/renderer",
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ES2020", "DOM"],
+    "types": []
   },
   "include": ["src/renderer/**/*", "src/shared/**/*"]
 }


### PR DESCRIPTION
- 从基础 tsconfig.json 中移除 types 限制，允许子配置自行定义
- 在 tsconfig.main.json 中明确设置只使用 node 类型（主进程环境）
- 在 tsconfig.renderer.json 中设置空 types 数组以使用所有可用类型（包括 DOM）
- 解决了测试文件无法识别 Jest 类型（describe、it、expect 等）的问题
- 解决了渲染进程文件无法识别 DOM 全局对象（window、document、alert 等）的问题

构建和测试现在都能正常运行，无 TypeScript 类型错误。