### PR TITLE
fix: 修复主进程编译输出路径与 package.json main 入口不匹配

### DIFF
--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist/main",
+    "outDir": "./dist",
     "types": ["node"]
   },
   "include": ["src/main/**/*", "src/shared/**/*"],


### PR DESCRIPTION
问题：
- package.json 中 main 字段指向 dist/main/index.js
- 但 TypeScript 编译输出到 dist/main/main/index.js
- 导致 Electron 无法找到入口文件

解决方案：
- 将 tsconfig.main.json 的 outDir 从 "./dist/main" 改为 "./dist"
- 由于继承了 tsconfig.json 的 rootDir: "./src"，编译输出现在正确保持目录结构
- src/main/index.ts → dist/main/index.js ✓
- src/main/preload.ts → dist/main/preload.js ✓
- src/shared/*.ts → dist/shared/*.js ✓

验证：
- ✓ package.json main 入口有效
- ✓ 所有必需文件正确生成
- ✓ 构建、测试、lint 全部通过